### PR TITLE
[Team  B] Possible swap to whisper-base

### DIFF
--- a/team_b/yappy/assets/models_config.json
+++ b/team_b/yappy/assets/models_config.json
@@ -15,27 +15,27 @@
       "size": 25.3
     },
     {
-      "id": "whisper_tiny",
-      "name": "Offline Whisper Model (Tiny)",
-      "url": "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-tiny.en.tar.bz2",
+      "id": "whisper_base",
+      "name": "Offline Whisper Model (Base)",
+      "url": "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-base.en.tar.bz2",
       "isCompressed": true,
       "type": "offline",
       "modelType": "whisper",
       "outputFiles": [
         {
-          "source": "sherpa-onnx-whisper-tiny.en/tiny.en-tokens.txt",
+          "source": "sherpa-onnx-whisper-base.en/base.en-tokens.txt",
           "destination": "offline_tokens.txt"
         },
         {
-          "source": "sherpa-onnx-whisper-tiny.en/tiny.en-decoder.int8.onnx",
+          "source": "sherpa-onnx-whisper-base.en/base.en-decoder.int8.onnx",
           "destination": "offline_decoder.onnx"
         },
         {
-          "source": "sherpa-onnx-whisper-tiny.en/tiny.en-encoder.int8.onnx",
+          "source": "sherpa-onnx-whisper-base.en/base.en-encoder.int8.onnx",
           "destination": "offline_encoder.onnx"
         }
       ],
-      "size": 113.0
+      "size": 199.0
     },
     {
       "id": "zipformer_online",


### PR DESCRIPTION
This changes the model config file to use whisper-base rather than whisper-tiny. Changing the first-pass zipformer model just isn't worth it but this might be.

HOWEVER, this does up the download size by ~100MB, and bumps our minimum specs from 2Gb RAM to 4Gb RAM.

If you want to test it, you need to up your emulator's RAM:

To increase the RAM of an Android Virtual Device (AVD) with a Google Play image, you can manually edit the AVD's configuration file. Access the AVD folder inside the .android directory, select your AVD folder, and open the config.ini file using a text editor. Modify the hw.ramSize= line to set the desired RAM size in MB, such as hw.ramSize=2048 for 2 GB of RAM (or 4096 for 4 GB). After saving the changes, close the running emulator and relaunch it.